### PR TITLE
Add rake setup to execute bundle install in picoruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Docker will solve it (TODO).
 ```
 git clone https://github.com/picoruby/R2P2.git
 cd R2P2
+rake setup
 rake
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,13 @@ end
 
 task :default => :all
 
+task :setup do
+  sh "git submodule update --init"
+  FileUtils.cd "lib/picoruby" do
+    sh "bundle install"
+  end
+end
+
 desc "build production"
 task :all => [:libmruby, :cmake_production, :build]
 


### PR DESCRIPTION
I encountered the following error when building with the rake command. The cause was that bundle install had not been performed in lib/picoruby. Therefore, I added the rake setup command to the procedure like prk_firmware and modified it to perform bundle install.

```sh
$ rake
rake test
GIT CHECKOUT DETACH /r2p2/lib/picoruby/build/repos/host/mruby-pico-compiler -> 75085ae1b031682f10c63574b970ed383c57272f
HEAD is now at 75085ae Fix gen_splat()
bundler: command not found: steep
Install missing gem executables with `bundle install`
rake aborted!
Command failed with status (127): [bundle exec steep check...]
/r2p2/lib/picoruby/rakefile:164:in `block in <top (required)>'
Tasks: TOP => test => steep
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [rake test...]
/r2p2/rakefile:41:in `block (2 levels) in <top (required)>'
/r2p2/rakefile:40:in `block in <top (required)>'
Tasks: TOP => default => all => libmruby
(See full trace by running task with --trace)
```