### PR TITLE
Use gcc-arm-embedded for building on macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,13 @@ The presentation video (JA) from RubyWorld Conference 2022: [Link](https://youtu
 - qemu-arm-static
 
 The author is working on WSL2-Ubuntu (x86-64 Windows host) and Ubuntu (x86-64 native)
+If you are building on macOS, please use `gcc-arm-embedded`.
+
+```
+brew install --cask gcc-arm-embedded
+```
 
 ### Build
-
-Build process below doesn't work on macOS.
-Docker will solve it (TODO).
 
 ```
 git clone https://github.com/picoruby/R2P2.git


### PR DESCRIPTION
When cross-compiling for the Raspberry Pi Pico on macOS, using `arm-none-eabi-gcc` results in an error being output.

https://github.com/raspberrypi/pico-feedback/issues/355

I have confirmed that using `gcc-arm-embedded` resolves this issue.
I will add this information to the README.