### PR TITLE
Update submodule picoruby for cross build on macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The presentation video (JA) from RubyWorld Conference 2022: [Link](https://youtu
 - qemu-arm-static
 
 The author is working on WSL2-Ubuntu (x86-64 Windows host) and Ubuntu (x86-64 native)
+
 If you are building on macOS, please use `gcc-arm-embedded`.
 
 ```


### PR DESCRIPTION
Update submodule picoruby for cross build on macOS.

Additionally, I have formatted the README for better readability.
Apologies for the readability issues.





