### PR TITLE
Introduce Keyboard

### DIFF
--- a/build_config/r2p2-microruby-pico2.rb
+++ b/build_config/r2p2-microruby-pico2.rb
@@ -53,4 +53,5 @@ MRuby::CrossBuild.new("r2p2-microruby-pico2") do |conf|
   conf.gembox "peripherals"
   conf.gem core: 'picoruby-shinonome'
   conf.gem core: 'picoruby-psg'
+  conf.gem core: 'picoruby-keyboard'
 end

--- a/build_config/r2p2-microruby-pico2_w.rb
+++ b/build_config/r2p2-microruby-pico2_w.rb
@@ -57,6 +57,5 @@ MRuby::CrossBuild.new("r2p2-microruby-pico2_w") do |conf|
   conf.gem core: 'picoruby-ble'
   conf.gem core: 'picoruby-net-http'
   conf.gem core: 'picoruby-net-ntp'
-  conf.gem core: 'picoruby-usb-hid'
-  conf.gem core: 'picoruby-keyboard-matrix'
+  conf.gem core: 'picoruby-keyboard'
 end

--- a/build_config/r2p2-microruby-pico2_w.rb
+++ b/build_config/r2p2-microruby-pico2_w.rb
@@ -57,4 +57,6 @@ MRuby::CrossBuild.new("r2p2-microruby-pico2_w") do |conf|
   conf.gem core: 'picoruby-ble'
   conf.gem core: 'picoruby-net-http'
   conf.gem core: 'picoruby-net-ntp'
+  conf.gem core: 'picoruby-usb-hid'
+  conf.gem core: 'picoruby-keyboard-matrix'
 end

--- a/build_config/r2p2-picoruby-pico.rb
+++ b/build_config/r2p2-picoruby-pico.rb
@@ -45,4 +45,6 @@ MRuby::CrossBuild.new("r2p2-picoruby-pico") do |conf|
   conf.gembox "shell"
   conf.gembox "peripherals"
   conf.gembox "peripheral_utils"
+  conf.gem core: 'picoruby-usb-hid'
+  conf.gem core: 'picoruby-keyboard-matrix'
 end

--- a/build_config/r2p2-picoruby-pico.rb
+++ b/build_config/r2p2-picoruby-pico.rb
@@ -45,6 +45,5 @@ MRuby::CrossBuild.new("r2p2-picoruby-pico") do |conf|
   conf.gembox "shell"
   conf.gembox "peripherals"
   conf.gembox "peripheral_utils"
-  conf.gem core: 'picoruby-usb-hid'
-  conf.gem core: 'picoruby-keyboard-matrix'
+  conf.gem core: 'picoruby-keyboard'
 end

--- a/build_config/r2p2-picoruby-pico2.rb
+++ b/build_config/r2p2-picoruby-pico2.rb
@@ -55,6 +55,7 @@ MRuby::CrossBuild.new("r2p2-picoruby-pico2") do |conf|
   conf.gembox "peripheral_utils"
   conf.gembox "peripherals"
   conf.gem core: 'picoruby-shinonome'
+  conf.gem core: 'picoruby-keyboard'
   conf.mrubyc_hal_arm
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/r2p2-picoruby-pico2_w.rb
+++ b/build_config/r2p2-picoruby-pico2_w.rb
@@ -59,4 +59,5 @@ MRuby::CrossBuild.new("r2p2-picoruby-pico2_w") do |conf|
   conf.gem core: 'picoruby-ble'
   conf.gem core: 'picoruby-net-http'
   conf.gem core: 'picoruby-net-ntp'
+  conf.gem core: 'picoruby-keyboard'
 end

--- a/build_config/r2p2-picoruby-pico_w.rb
+++ b/build_config/r2p2-picoruby-pico_w.rb
@@ -53,4 +53,5 @@ MRuby::CrossBuild.new("r2p2-picoruby-pico_w") do |conf|
   # Rapi Pico's flash ROM (2MB) can't hold both net and ble
   conf.gem core: 'picoruby-net'
   # conf.gem core: 'picoruby-ble'
+  conf.gem core: 'picoruby-keyboard'
 end

--- a/include/tusb_config.h
+++ b/include/tusb_config.h
@@ -115,7 +115,7 @@
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              2
 #define CFG_TUD_MSC              1
-#define CFG_TUD_HID              0
+#define CFG_TUD_HID              3
 #define CFG_TUD_MIDI             0
 #define CFG_TUD_VENDOR           0
 
@@ -125,6 +125,9 @@
 
 // CDC Endpoint transfer buffer size, more is faster
 #define CFG_TUD_CDC_EP_BUFSIZE    512
+
+// HID buffer size
+#define CFG_TUD_HID_EP_BUFSIZE    16
 
 // MSC Buffer size of Device Mass storage
 #if defined(PICORUBY_MSC_FLASH)

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -112,6 +112,10 @@ enum
   #define EPNUM_MSC_OUT       0x08
   #define EPNUM_MSC_IN        0x88
 
+  #define EPNUM_HID_KEYBOARD  0x89
+  #define EPNUM_HID_MOUSE     0x8A
+  #define EPNUM_HID_CONSUMER  0x8B
+
 #elif CFG_TUSB_MCU == OPT_MCU_CXD56
   // CXD56 USB driver has fixed endpoint type (bulk/interrupt/iso) and direction (IN/OUT) by its number
   // 0 control (IN/OUT), 1 Bulk (IN), 2 Bulk (OUT), 3 In (IN), 4 Bulk (IN), 5 Bulk (OUT), 6 In (IN)
@@ -126,6 +130,10 @@ enum
   #define EPNUM_MSC_OUT       0x07
   #define EPNUM_MSC_IN        0x08
 
+  #define EPNUM_HID_KEYBOARD  0x89
+  #define EPNUM_HID_MOUSE     0x8A
+  #define EPNUM_HID_CONSUMER  0x8B
+
 #elif defined(TUD_ENDPOINT_ONE_DIRECTION_ONLY)
   // MCUs that don't support a same endpoint number with different direction IN and OUT
   //    e.g EP1 OUT & EP1 IN cannot exist together
@@ -139,6 +147,10 @@ enum
 
   #define EPNUM_MSC_OUT       0x07
   #define EPNUM_MSC_IN        0x88
+
+  #define EPNUM_HID_KEYBOARD  0x89
+  #define EPNUM_HID_MOUSE     0x8A
+  #define EPNUM_HID_CONSUMER  0x8B
 
 #else
   #define EPNUM_CDC_0_NOTIF   0x81

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -92,6 +92,9 @@ enum
   ITF_NUM_CDC_1,
   ITF_NUM_CDC_1_DATA,
   ITF_NUM_MSC,
+  ITF_NUM_HID_KEYBOARD,
+  ITF_NUM_HID_MOUSE,
+  ITF_NUM_HID_CONSUMER,
   ITF_NUM_TOTAL
 };
 
@@ -149,9 +152,43 @@ enum
   #define EPNUM_MSC_OUT       0x05
   #define EPNUM_MSC_IN        0x85
 
+  #define EPNUM_HID_KEYBOARD  0x86
+  #define EPNUM_HID_MOUSE     0x87
+  #define EPNUM_HID_CONSUMER  0x88
+
 #endif
 
-#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + CFG_TUD_CDC * TUD_CDC_DESC_LEN + TUD_MSC_DESC_LEN)
+#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + CFG_TUD_CDC * TUD_CDC_DESC_LEN + TUD_MSC_DESC_LEN + CFG_TUD_HID * TUD_HID_DESC_LEN)
+
+// HID Report Descriptor for Keyboard
+uint8_t const desc_hid_keyboard_report[] =
+{
+  TUD_HID_REPORT_DESC_KEYBOARD()
+};
+
+// HID Report Descriptor for Mouse
+uint8_t const desc_hid_mouse_report[] =
+{
+  TUD_HID_REPORT_DESC_MOUSE()
+};
+
+// HID Report Descriptor for Consumer Control
+uint8_t const desc_hid_consumer_report[] =
+{
+  TUD_HID_REPORT_DESC_CONSUMER()
+};
+
+// Required callback for HID report descriptor
+uint8_t const * tud_hid_descriptor_report_cb(uint8_t instance)
+{
+  switch(instance)
+  {
+    case 0: return desc_hid_keyboard_report;
+    case 1: return desc_hid_mouse_report;
+    case 2: return desc_hid_consumer_report;
+    default: return NULL;
+  }
+}
 
 // full speed configuration
 uint8_t const desc_fs_configuration[] =
@@ -167,6 +204,15 @@ uint8_t const desc_fs_configuration[] =
 
   // Interface number, string index, EP Out & EP In address, EP size
   TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 5, EPNUM_MSC_OUT, EPNUM_MSC_IN, 64),
+
+  // HID Keyboard
+  TUD_HID_DESCRIPTOR(ITF_NUM_HID_KEYBOARD, 7, HID_ITF_PROTOCOL_KEYBOARD, sizeof(desc_hid_keyboard_report), EPNUM_HID_KEYBOARD, CFG_TUD_HID_EP_BUFSIZE, 10),
+
+  // HID Mouse
+  TUD_HID_DESCRIPTOR(ITF_NUM_HID_MOUSE, 8, HID_ITF_PROTOCOL_NONE, sizeof(desc_hid_mouse_report), EPNUM_HID_MOUSE, CFG_TUD_HID_EP_BUFSIZE, 10),
+
+  // HID Consumer Control
+  TUD_HID_DESCRIPTOR(ITF_NUM_HID_CONSUMER, 9, HID_ITF_PROTOCOL_NONE, sizeof(desc_hid_consumer_report), EPNUM_HID_CONSUMER, CFG_TUD_HID_EP_BUFSIZE, 10),
 };
 
 #if TUD_OPT_HIGH_SPEED
@@ -186,6 +232,15 @@ uint8_t const desc_hs_configuration[] =
 
   // Interface number, string index, EP Out & EP In address, EP size
   TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 5, EPNUM_MSC_OUT, EPNUM_MSC_IN, 512),
+
+  // HID Keyboard
+  TUD_HID_DESCRIPTOR(ITF_NUM_HID_KEYBOARD, 7, HID_ITF_PROTOCOL_KEYBOARD, sizeof(desc_hid_keyboard_report), EPNUM_HID_KEYBOARD, CFG_TUD_HID_EP_BUFSIZE, 10),
+
+  // HID Mouse
+  TUD_HID_DESCRIPTOR(ITF_NUM_HID_MOUSE, 8, HID_ITF_PROTOCOL_NONE, sizeof(desc_hid_mouse_report), EPNUM_HID_MOUSE, CFG_TUD_HID_EP_BUFSIZE, 10),
+
+  // HID Consumer Control
+  TUD_HID_DESCRIPTOR(ITF_NUM_HID_CONSUMER, 9, HID_ITF_PROTOCOL_NONE, sizeof(desc_hid_consumer_report), EPNUM_HID_CONSUMER, CFG_TUD_HID_EP_BUFSIZE, 10),
 };
 
 // other speed configuration
@@ -274,6 +329,9 @@ char const *string_desc_arr[] =
   "PicoRuby CDC",                // 4: CDC Interface 0 (Application)
   "PicoRuby MSC",                // 5: MSC Interface
   "PicoRuby CDC Debug",          // 6: CDC Interface 1 (Debug)
+  "PicoRuby HID Keyboard",       // 7: HID Keyboard
+  "PicoRuby HID Mouse",          // 8: HID Mouse
+  "PicoRuby HID Consumer Control", // 9: HID Consumer Control
 };
 
 static uint16_t _desc_str[32 + 1];


### PR DESCRIPTION
This pull request adds support for multiple HID (Human Interface Device) interfaces—specifically keyboard, mouse, and consumer control—to the PicoRuby firmware. It updates the USB configuration, descriptors, and build files to enable and configure these HID devices across multiple board variants.

**USB HID support and configuration:**

* Increased the number of HID interfaces enabled by setting `CFG_TUD_HID` to 3 and added a buffer size definition for HID endpoints in `tusb_config.h`. [[1]](diffhunk://#diff-af2f52a7c986d73bc835abb03cd67f37fe228efbacab2472febc26c178369693L118-R118) [[2]](diffhunk://#diff-af2f52a7c986d73bc835abb03cd67f37fe228efbacab2472febc26c178369693R129-R131)
* Updated USB interface and endpoint enumerations to include keyboard, mouse, and consumer control HID devices in `usb_descriptors.c`. [[1]](diffhunk://#diff-40b405bc8e91746f1ee25c24a2cf6e409689d83f380d95094b60cfbf9b359360R95-R97) [[2]](diffhunk://#diff-40b405bc8e91746f1ee25c24a2cf6e409689d83f380d95094b60cfbf9b359360R115-R118) [[3]](diffhunk://#diff-40b405bc8e91746f1ee25c24a2cf6e409689d83f380d95094b60cfbf9b359360R133-R136) [[4]](diffhunk://#diff-40b405bc8e91746f1ee25c24a2cf6e409689d83f380d95094b60cfbf9b359360R151-R154) [[5]](diffhunk://#diff-40b405bc8e91746f1ee25c24a2cf6e409689d83f380d95094b60cfbf9b359360R167-R203)
* Added HID report descriptors and a callback to provide the correct report descriptor for each HID instance.
* Extended the USB configuration descriptors for both full speed and high speed to include the new HID interfaces. [[1]](diffhunk://#diff-40b405bc8e91746f1ee25c24a2cf6e409689d83f380d95094b60cfbf9b359360R219-R227) [[2]](diffhunk://#diff-40b405bc8e91746f1ee25c24a2cf6e409689d83f380d95094b60cfbf9b359360R247-R255)
* Added string descriptors for the new HID interfaces.

**Build configuration updates:**

* Added the `picoruby-keyboard` core gem to all relevant board build configuration files to ensure HID keyboard support is included in the firmware. [[1]](diffhunk://#diff-4c585dc66b1f973a0e0e145603ea68c34e9cd1ea6e99649a0e30e20c6cdd2cb4R56) [[2]](diffhunk://#diff-9363b32c325a47be917cdd7c329f4f502131f68c39986d1da1bd003185e0ce89R60) [[3]](diffhunk://#diff-7ae138e35ddd00a27b7546f926c6977bcc3956988121773c2c8fbc6792dbcaebR48) [[4]](diffhunk://#diff-9afaa961ea6875a5ef65161cb610d95c622df5f9968b3c2b2fc330fac1c748acR58) [[5]](diffhunk://#diff-e6600e3a6653a4413946cc9416a3ddc5ad71cb5536a0420620e75bf976d0d4deR62) [[6]](diffhunk://#diff-3c6ee230d6eed7702e4b71f3d4684fe6678c1f9449a7fec339d845d2b37adbddR56)

**Submodule update:**

* Updated the `picoruby` submodule to the latest commit, likely to pull in upstream changes required for HID support.